### PR TITLE
Adds support for salting a fingerprint dynamically

### DIFF
--- a/fingerprinter/cli.py
+++ b/fingerprinter/cli.py
@@ -19,6 +19,8 @@ def get_parser() -> argparse.ArgumentParser:
                         help='Set log level to INFO')
     parser.add_argument('--debug', '-g', action='store_true', default=False,
                         help='Set log level to DEBUG')
+    parser.add_argument('--salt', action='store', default='',
+                        help='Use this to help differentiate one build from another based on dynamic context. Any value is accepted.')
     return parser
 
 
@@ -41,7 +43,7 @@ def main():
     logging.debug("Starting in DEBUG mode")
 
     fp = Fingerprinter(config)
-    print(fp.get_fingerprint(args.target))
+    print(fp.get_fingerprint(args.target, args.salt))
 
 
 if __name__ == "__main__":

--- a/fingerprinter/fingerprinter.py
+++ b/fingerprinter/fingerprinter.py
@@ -104,8 +104,11 @@ class Fingerprinter:
 
     def get_fingerprint_bytes(self, target: str) -> bytes:
         return self.get_fingerprint(target).encode('UTF-8')
+    
+    def get_string_fingerprint(self, val: str) -> bytes:
+        return hashlib.sha256(val.encode('UTF-8')).hexdigest().encode('UTF-8')
 
-    def get_fingerprint(self, target: str) -> str:
+    def get_fingerprint(self, target: str, salt: Optional[str] = None) -> str:
         logging.debug(f"Getting fingerprint for {target}")
         target = self.config.targets[target]  # Raises KeyError
         h = hashlib.sha256()
@@ -116,5 +119,9 @@ class Fingerprinter:
         for path in sorted(target.include_paths):
             logging.debug(f'Resolving files for path "{path}"')
             h.update(self.get_path_fingerprint(path))
+            
+        if salt:
+            logging.debug(f'Adding salt: {salt}')
+            h.update(self.get_string_fingerprint(salt))
 
         return h.hexdigest()


### PR DESCRIPTION
This change allows dependents to provide salt to a fingerprint; this can be helpful when certain aspects of the workflow need to be repeated based on new data (like build arguments or version numbers), even if the file contents of the target haven't changed.