### PR TITLE
Use RawTextFormatter (leaves indent)

### DIFF
--- a/fingerprinter/cli.py
+++ b/fingerprinter/cli.py
@@ -1,6 +1,7 @@
 import argparse
 import logging
 import os.path
+import textwrap
 
 import yaml
 
@@ -10,7 +11,7 @@ from .models import BuildConfig
 
 def get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description="""
+        description=textwrap.dedent("""
         This tool can be used to build deterministic fingerprints, that
         are smartly flagged for updates based on configuration you provide.
         For full documentation, please refer to the README at
@@ -32,7 +33,7 @@ def get_parser() -> argparse.ArgumentParser:
         build-targets  REQUIRES: -c/c--config (if not default)
                        OUTPUTS: An acceptable order in which to build all configured targets
 
-        """,
+        """),
         usage="fingerprinter [-o <OUTPUT_TYPE>] [-f <CONFIGURATION_FILE] [-t TARGET] [OPTIONS]",
         formatter_class=argparse.RawTextHelpFormatter,
     )

--- a/fingerprinter/cli.py
+++ b/fingerprinter/cli.py
@@ -11,29 +11,30 @@ from .models import BuildConfig
 def get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="""
-        This tool can be used to build deterministic fingerprints, that 
+        This tool can be used to build deterministic fingerprints, that
         are smartly flagged for updates based on configuration you provide.
         For full documentation, please refer to the README at
-            https://github.com/uwit-iam/fingerprinter/tree/main/README.md        
-       
-       
+            https://github.com/uwit-iam/fingerprinter/tree/main/README.md
+
+
         Behavior is mainly controlled by the output type (-o/--output):
-        
-        js/json        REQUIRES: -t/--target 
+
+        js/json        REQUIRES: -t/--target
                                  -c/--config (if not default)
                        OUTPUTS: the json build configuration for the target
                        This is the default output type
-                       
+
         pjs/pretty-json
                        Same as js/json, but the output is easier to read
-        
+
         build-script   OUTPUTS: The absolute path to the 'build-fp-targets.sh' script.
-        
+
         build-targets  REQUIRES: -c/c--config (if not default)
                        OUTPUTS: An acceptable order in which to build all configured targets
-         
+
         """,
         usage="fingerprinter [-o <OUTPUT_TYPE>] [-f <CONFIGURATION_FILE] [-t TARGET] [OPTIONS]",
+        formatter_class=argparse.RawTextHelpFormatter,
     )
     parser.add_argument('--config-file', '-f', default='fingerprints.yaml',
                         help='The config file you want to use to generate fingerprints.')


### PR DESCRIPTION
Before

```
$ poetry run fingerprinter --help
usage: fingerprinter [-o <OUTPUT_TYPE>] [-f <CONFIGURATION_FILE] [-t TARGET] [OPTIONS]

This tool can be used to build deterministic fingerprints, that are smartly flagged for updates based on configuration you provide. For full documentation, please
refer to the README at https://github.com/uwit-iam/fingerprinter/tree/main/README.md Behavior is mainly controlled by the output type (-o/--output): js/json
REQUIRES: -t/--target -c/--config (if not default) OUTPUTS: the json build configuration for the target This is the default output type pjs/pretty-json Same as
js/json, but the output is easier to read build-script OUTPUTS: The absolute path to the 'build-fp-targets.sh' script. build-targets REQUIRES: -c/c--config (if
not default) OUTPUTS: An acceptable order in which to build all configured targets

options:
  -h, --help            show this help message and exit
  --config-file CONFIG_FILE, -f CONFIG_FILE
                        The config file you want to use to generate fingerprints.
  --target TARGET, -t TARGET
                        The target from the config file whose configuration you want to get
  --verbose, -v         Set log level to INFO
  --debug, -g           Set log level to DEBUG
  --salt SALT           Use this to help differentiate one build from another based on dynamic context. Any value is accepted.
  --output OUTPUT, -o OUTPUT
                        fingerprint/fp, build-script, build-targets, json/js, pretty-json/pjs, query/q, release-target
  --build-arg BUILD_ARG
                        Can be provided multiple times. Any build arg provided this way will be treated as salt, but only build-args declared in the build
                        configuration file will be passed into docker. This is to prevent awkward vulnerabilities.

```

after

```
$ poetry run fingerprinter --help
usage: fingerprinter [-o <OUTPUT_TYPE>] [-f <CONFIGURATION_FILE] [-t TARGET] [OPTIONS]

        This tool can be used to build deterministic fingerprints, that
        are smartly flagged for updates based on configuration you provide.
        For full documentation, please refer to the README at
            https://github.com/uwit-iam/fingerprinter/tree/main/README.md

        Behavior is mainly controlled by the output type (-o/--output):

        js/json        REQUIRES: -t/--target
                                 -c/--config (if not default)
                       OUTPUTS: the json build configuration for the target
                       This is the default output type

        pjs/pretty-json
                       Same as js/json, but the output is easier to read

        build-script   OUTPUTS: The absolute path to the 'build-fp-targets.sh' script.

        build-targets  REQUIRES: -c/c--config (if not default)
                       OUTPUTS: An acceptable order in which to build all configured targets



options:
  -h, --help            show this help message and exit
  --config-file CONFIG_FILE, -f CONFIG_FILE
                        The config file you want to use to generate fingerprints.
  --target TARGET, -t TARGET
                        The target from the config file whose configuration you want to get
  --verbose, -v         Set log level to INFO
  --debug, -g           Set log level to DEBUG
  --salt SALT           Use this to help differentiate one build from another based on dynamic context. Any value is accepted.
  --output OUTPUT, -o OUTPUT
                        fingerprint/fp, build-script, build-targets, json/js, pretty-json/pjs, query/q, release-target
  --build-arg BUILD_ARG
                        Can be provided multiple times. Any build arg provided this way will be treated as salt, but only build-args declared in the build configuration file will be passed into docker. This is to prevent awkward vulnerabilities.
```