### PR TITLE
Add --utc flag to date command

### DIFF
--- a/fingerprinter/build.sh
+++ b/fingerprinter/build.sh
@@ -230,7 +230,7 @@ function deploy {
     echo "Could not determine version to deploy. Please provide the -dv/-dversion
           argument or create a new release with '--release'"
   fi
-  local deploy_ts="$(date +%Y.%m.%d.%H.%M.%S)"
+  local deploy_ts="$(date --utc +%Y.%m.%d.%H.%M.%S)"
   local deploy_id="${deploy_ts}.v${deploy_version}"
   local deploy_tag="deploy-${deploy_stage}.${deploy_id}"
   local release_target=$(get_release_target | jq -r .dockerTag)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "uw-it-build-fingerprinter"
-version = "0.2.8"
+version = "0.2.9"
 description = ""
 authors = ["Tom Thorogood <tom@tomthorogood.com>"]
 packages = [


### PR DESCRIPTION
Companion piece to [common-build-scripts PR](https://github.com/UWIT-IAM/common-build-scripts/pull/25)

tl;dr

* images are sorted by timestamp
* GitHub runners are on UTC
* now local runs won't be 7/8 hours behind